### PR TITLE
[feature] Add policy filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ func main() {
 }
 ```
 
+## Filtered Policies
+
+```go
+import "gopkg.in/mgo.v2/bson"
+
+// This adapter also implements the FilteredAdapter interface. This allows for
+// efficent, scalable enforcement of very large policies:
+filter := &bson.M{"v0": "alice"}
+e.LoadFilteredPolicy(filter)
+
+// The loaded policy is now a subset of the policy in storage, containing only
+// the policy lines that match the provided filter. This filter should be a
+// valid MongoDB selector using BSON. A filtered policy cannot be saved.
+```
+
 ## Getting Help
 
 - [Casbin](https://github.com/casbin/casbin)

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/casbin/casbin"
 	"github.com/casbin/casbin/util"
+	"gopkg.in/mgo.v2/bson"
 )
 
 var testDbURL = os.Getenv("TEST_MONGODB_URL")
@@ -129,6 +130,50 @@ func TestAdapter(t *testing.T) {
 		t.Errorf("Expected LoadPolicy() to be successful; got %v", err)
 	}
 	testGetPolicy(t, e, [][]string{{"bob", "data2", "write"}})
+
+	e.RemoveFilteredPolicy(2, "write")
+	if err := e.LoadPolicy(); err != nil {
+		t.Errorf("Expected LoadPolicy() to be successful; got %v", err)
+	}
+	testGetPolicy(t, e, [][]string{})
+}
+
+func TestFilteredAdapter(t *testing.T) {
+	// Now the DB has policy, so we can provide a normal use case.
+	// Create an adapter and an enforcer.
+	// NewEnforcer() will load the policy automatically.
+	a := NewAdapter(getDbURL())
+	e := casbin.NewEnforcer("examples/rbac_model.conf", a)
+
+	// Load filtered policies from the database.
+	e.AddPolicy("alice", "data1", "write")
+	e.AddPolicy("bob", "data2", "write")
+	// Reload the filtered policy from the storage.
+	filter := &bson.M{"v0": "bob"}
+	if err := e.LoadFilteredPolicy(filter); err != nil {
+		t.Errorf("Expected LoadFilteredPolicy() to be successful; got %v", err)
+	}
+	// Only bob's policy should have been loaded
+	testGetPolicy(t, e, [][]string{{"bob", "data2", "write"}})
+
+	// Verify that alice's policy remains intact in the database.
+	filter = &bson.M{"v0": "alice"}
+	if err := e.LoadFilteredPolicy(filter); err != nil {
+		t.Errorf("Expected LoadFilteredPolicy() to be successful; got %v", err)
+	}
+	// Only alice's policy should have been loaded,
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "write"}})
+
+	// Test safe handling of SavePolicy when using filtered policies.
+	if err := e.SavePolicy(); err == nil {
+		t.Errorf("Expected SavePolicy() to fail for a filtered policy")
+	}
+	if err := e.LoadPolicy(); err != nil {
+		t.Errorf("Expected LoadPolicy() to be successful; got %v", err)
+	}
+	if err := e.SavePolicy(); err != nil {
+		t.Errorf("Expected SavePolicy() to be successful; got %v", err)
+	}
 
 	e.RemoveFilteredPolicy(2, "write")
 	if err := e.LoadPolicy(); err != nil {


### PR DESCRIPTION
Allow for filtered policy loading, so that the loaded policy is
a targeted subset of the policy in storage. This allows the policy
enforcement to more effectively scale for very large policies in
a multi-tenant environment by only loading the policies relevant
to the requested tenant.

To protect the full policy from accidental corruption, a filtered
policy cannot be saved back to storage.