### PR TITLE
Fixed a bug. When do RemoveFilteredPolicy(0,sub,,act) doesn't affect …

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -271,22 +271,34 @@ func (a *adapter) RemoveFilteredPolicy(sec string, ptype string, fieldIndex int,
 	selector["ptype"] = ptype
 
 	if fieldIndex <= 0 && 0 < fieldIndex+len(fieldValues) {
-		selector["v0"] = fieldValues[0-fieldIndex]
+		if fieldValues[0-fieldIndex] != "" {
+			selector["v0"] = fieldValues[0-fieldIndex]
+		}
 	}
 	if fieldIndex <= 1 && 1 < fieldIndex+len(fieldValues) {
-		selector["v1"] = fieldValues[1-fieldIndex]
+		if fieldValues[1-fieldIndex] != "" {
+			selector["v1"] = fieldValues[1-fieldIndex]
+		}
 	}
 	if fieldIndex <= 2 && 2 < fieldIndex+len(fieldValues) {
-		selector["v2"] = fieldValues[2-fieldIndex]
+		if fieldValues[2-fieldIndex] != "" {
+			selector["v2"] = fieldValues[2-fieldIndex]
+		}
 	}
 	if fieldIndex <= 3 && 3 < fieldIndex+len(fieldValues) {
-		selector["v3"] = fieldValues[3-fieldIndex]
+		if fieldValues[3-fieldIndex] != "" {
+			selector["v3"] = fieldValues[3-fieldIndex]
+		}
 	}
 	if fieldIndex <= 4 && 4 < fieldIndex+len(fieldValues) {
-		selector["v4"] = fieldValues[4-fieldIndex]
+		if fieldValues[4-fieldIndex] != "" {
+			selector["v4"] = fieldValues[4-fieldIndex]
+		}
 	}
 	if fieldIndex <= 5 && 5 < fieldIndex+len(fieldValues) {
-		selector["v5"] = fieldValues[5-fieldIndex]
+		if fieldValues[5-fieldIndex] != "" {
+			selector["v5"] = fieldValues[5-fieldIndex]
+		}
 	}
 
 	_, err := a.collection.RemoveAll(selector)

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -137,6 +137,33 @@ func TestAdapter(t *testing.T) {
 	}
 	testGetPolicy(t, e, [][]string{})
 }
+func TestDeleteFilteredAdapter(t *testing.T) {
+	a := NewAdapter(getDbURL())
+	e := casbin.NewEnforcer("examples/rbac_tenant_service.conf", a)
+
+	e.AddPolicy("domain1", "alice", "data3", "read", "accept", "service1")
+	e.AddPolicy("domain1", "alice", "data3", "write", "accept", "service2")
+
+	// Reload the policy from the storage to see the effect.
+	if err := e.LoadPolicy(); err != nil {
+		t.Errorf("Expected LoadPolicy() to be successful; got %v", err)
+	}
+	// The policy has a new rule: {"alice", "data1", "write"}.
+	testGetPolicy(t, e, [][]string{{"domain1", "alice", "data3", "read", "accept", "service1"},
+		{"domain1", "alice", "data3", "write", "accept", "service2"}})
+	// test RemoveFiltered Policy with "" fileds
+	e.RemoveFilteredPolicy(0, "domain1", "", "", "read")
+	if err := e.LoadPolicy(); err != nil {
+		t.Errorf("Expected LoadPolicy() to be successful; got %v", err)
+	}
+	testGetPolicy(t, e, [][]string{{"domain1", "alice", "data3", "write", "accept", "service2"}})
+
+	e.RemoveFilteredPolicy(0, "domain1", "", "", "", "", "service2")
+	if err := e.LoadPolicy(); err != nil {
+		t.Errorf("Expected LoadPolicy() to be successful; got %v", err)
+	}
+	testGetPolicy(t, e, [][]string{})
+}
 
 func TestFilteredAdapter(t *testing.T) {
 	// Now the DB has policy, so we can provide a normal use case.

--- a/examples/rbac_tenant_service.conf
+++ b/examples/rbac_tenant_service.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = tenant, sub, obj, act, service
+
+[policy_definition]
+p =tenant, sub, obj, act, service, eft
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = priority(p.eft) || deny
+
+[matchers]
+m = r.tenant == p.tenant && g(r.sub, p.sub) && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == "*") && (r.service == p.service || p.service == "*")


### PR DESCRIPTION
Fixed a bug. When do RemoveFilteredPolicy like (0,sub,“”,act) doesn't affect the policy in the storage.
Adds unit test cases to cover new functionality.