### PR TITLE
feat: support updating policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
         with:
           go-version: 1.14
 
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.7.0
+        with:
+          mongodb-version: 4.4
+          mongodb-replica-set: test-rs
+          mongodb-port: 42069
+
       - uses: actions/checkout@v2
       - name: Run Unit tests
         run: go test -v -coverprofile=./profile.cov ./...


### PR DESCRIPTION
Signed-off-by: abingcbc <abingcbc626@gmail.com>

Fix: https://github.com/casbin/mongodb-adapter/issues/45

Notes: MongoDB starts to support transactions from v4. But txn is only allowed with a replica set. 
So in `mongodb-adapter`, for standalone MongoDB server, `UpdateFilteredPolicies` is working in a non-transactional way which is unsafe and not recommended.