### PR TITLE
feat: improve performance of AddPolicies

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -367,20 +367,16 @@ func (a *adapter) AddPolicy(sec string, ptype string, rule []string) error {
 
 // AddPolicies adds policy rules to the storage.
 func (a *adapter) AddPolicies(sec string, ptype string, rules [][]string) error {
-	var lines []CasbinRule
+	var lines []interface{}
 	for _, rule := range rules {
 		line := savePolicyLine(ptype, rule)
 		lines = append(lines, line)
 	}
-
-	for _, line := range lines {
-		ctx, cancel := context.WithTimeout(context.TODO(), a.timeout)
-		defer cancel()
-		if _, err := a.collection.InsertOne(ctx, line); err != nil {
-			return err
-		}
+	ctx, cancel := context.WithTimeout(context.TODO(), a.timeout)
+	defer cancel()
+	if _, err := a.collection.InsertMany(ctx, lines); err != nil {
+		return err
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Summary:
Improve Performance of AddPolicies in MongoDB Adapter

Description:
This Pull Request aims to enhance the performance of the `AddPolicies` function in the Casbin MongoDB adapter. The current implementation of `AddPolicies` inserts each policy rule using the InsertOne method.
However, inserting multiple lines in a single operation is more efficient. Therefore, this update refactors `AddPolicies` to utilize `InsertMany`, significantly reducing the number of database operations and potentially improving overall performance for adding multiple policies.

Changes:
* Changed the `lines` slice to a slice of `interface{}` to accommodate the requirements of the `InsertMany` method.
* Replaced the `InsertOne` method with `InsertMany` for inserting multiple policy lines in a single database call.
