### PR TITLE
feat: add prepareIndexes() method to NewAdapterByDB()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,17 @@ require (
 	github.com/casbin/casbin/v2 v2.71.1
 	go.mongodb.org/mongo-driver v1.12.0
 )
+
+require (
+	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
+	golang.org/x/text v0.7.0 // indirect
+)


### PR DESCRIPTION
I have discovered that when using the "NewAdapterByDB" function, it was missing the index preparation phase. To address this, I've decided to contribute by ensuring that this function performs the same initialization steps as other methods.

This pull request introduces several improvements to the MongoDB adapter:
1. Refactored the NewAdapterByDB function:
   - Added a new 'collection' variable to directly access the specified collection.
   - Implemented error handling for a.prepareIndexes() call.
2. Added a new prepareIndexes() method:
   - This method creates necessary indexes for improved query performance.
   - It's called during adapter initialization to ensure indexes are set up.
3. Updated the open() method:
   - Added error handling for a.prepareIndexes() call.
4. Modified the createIndex() call:
   - Updated to use the latest MongoDB driver syntax for index creation.
5. Updated go.mod dependencies:
    - Added several new indirect dependencies, likely due to updates in the MongoDB driver or other related packages.