### PR TITLE
feat: fix CI workflow to use the correct go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: '1.20'
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0


### PR DESCRIPTION
Fix: https://github.com/casbin/mongodb-adapter/issues/69

Fix can be previewed on https://github.com/slhmy/mongodb-adapter/actions/runs/15201227007 .

Quote `go-version: '1.20'` is necessary since yaml will take 1.20 as number to 1.2 .