### PR TITLE
ci: fix CI workflow startup failure and polish README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,27 +9,31 @@ jobs:
 
     services:
       mongodb:
-        image: mongo
+        image: mongo:4.4
         ports:
           - 27017:27017
+        options: >-
+          --health-cmd "mongo --eval 'db.runCommand({ping:1})'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.20'
 
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.7.0
-        with:
-          mongodb-version: 4.4
-          mongodb-replica-set: test-rs
-          mongodb-port: 42069
+      - name: Start MongoDB replica set (port 42069)
+        run: |
+          docker run -d --name mongo-rs -p 42069:27017 mongo:4.4 --replSet test-rs
+          for i in $(seq 1 30); do
+            docker exec mongo-rs mongo --eval "db.runCommand({ping:1})" >/dev/null 2>&1 && break
+            sleep 1
+          done
+          docker exec mongo-rs mongo --eval "rs.initiate({_id:'test-rs', members:[{_id:0, host:'127.0.0.1:42069'}]})"
 
-      - uses: actions/checkout@v2
       - name: Run Unit tests
         run: go test -v -coverprofile=./profile.cov ./...
-
-      - uses: shogo82148/actions-goveralls@v1
-        with:
-          path-to-profile: ./profile.cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,26 +70,39 @@ jobs:
           PRERELEASE: ${{ steps.meta.outputs.prerelease }}
           BASENAME: ${{ steps.meta.outputs.basename }}
         run: |
-          if [[ "${PRERELEASE}" == "true" ]]; then
-            printf 'Release candidate for version `%s`. This is **not** a released version; it is the source artifact for the Apache release vote.\n' "${VERSION%%-rc*}"
-          else
-            printf 'Version `%s`.\n' "${VERSION}"
-          fi
-          printf '\n| Asset | Description |\n| --- | --- |\n'
-          printf '| `%s.tar.gz` | Source release |\n' "${BASENAME}"
-          printf '| `%s.tar.gz.sha512` | SHA-512 checksum |\n\n' "${BASENAME}"
-          printf 'The release manager signs the tarball locally with their own GPG key before starting the vote.\n'
-        # shellcheck: the script above deliberately keeps release notes minimal
-        # (per the project's policy: no extra Apache processes in CI).
+          set -euo pipefail
+          {
+            if [[ "${PRERELEASE}" == "true" ]]; then
+              printf 'Release candidate for version `%s`. This is **not** a released version; it is the source artifact for the Apache release vote.\n\n' "${VERSION%%-rc*}"
+            else
+              printf 'Version `%s`.\n\n' "${VERSION}"
+            fi
+            printf '| Asset | Description |\n| --- | --- |\n'
+            printf '| `%s.tar.gz` | Source release |\n' "${BASENAME}"
+            printf '| `%s.tar.gz.sha512` | SHA-512 checksum |\n\n' "${BASENAME}"
+            printf 'The release manager signs the tarball locally with their own GPG key before starting the vote.\n'
+          } > release-notes.md
+          cat release-notes.md
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: Casbin MongoDB Adapter ${{ steps.meta.outputs.tag }}
-          body_path: release-notes.md
-          draft: false
-          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
-          files: |
-            dist/${{ steps.meta.outputs.basename }}.tar.gz
-            dist/${{ steps.meta.outputs.basename }}.tar.gz.sha512
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            # A candidate is never "latest" - it has not been voted on yet.
+            KIND=(--prerelease --latest=false)
+          else
+            KIND=(--latest)
+          fi
+
+          # Idempotent, so a re-run after a failure further down still works.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, updating it."
+            gh release edit "$TAG" --title "Casbin MongoDB Adapter $TAG" --notes-file release-notes.md "${KIND[@]}"
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" --title "Casbin MongoDB Adapter $TAG" --notes-file release-notes.md "${KIND[@]}" dist/*
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
-MongoDB Adapter [![CI](https://github.com/casbin/mongodb-adapter/actions/workflows/ci.yml/badge.svg)](https://github.com/casbin/mongodb-adapter/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/github/casbin/mongodb-adapter/badge.svg?branch=master)](https://coveralls.io/github/casbin/mongodb-adapter?branch=master) [![Godoc](https://godoc.org/github.com/casbin/mongodb-adapter?status.svg)](https://godoc.org/github.com/casbin/mongodb-adapter)
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+MongoDB Adapter
 ====
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/apache/casbin-mongodb-adapter)](https://goreportcard.com/report/github.com/apache/casbin-mongodb-adapter)
+[![Build](https://github.com/apache/casbin-mongodb-adapter/actions/workflows/ci.yml/badge.svg)](https://github.com/apache/casbin-mongodb-adapter/actions/workflows/ci.yml)
+[![Godoc](https://godoc.org/github.com/apache/casbin-mongodb-adapter?status.svg)](https://pkg.go.dev/github.com/casbin/mongodb-adapter/v4)
+[![Release](https://img.shields.io/github/release/apache/casbin-mongodb-adapter.svg)](https://github.com/apache/casbin-mongodb-adapter/releases/latest)
+[![Discord](https://img.shields.io/discord/1022748306096537660?logo=discord&label=discord&color=5865F2)](https://discord.gg/S5UjpzGZjN)
+[![Sourcegraph](https://sourcegraph.com/github.com/apache/casbin-mongodb-adapter/-/badge.svg)](https://sourcegraph.com/github.com/apache/casbin-mongodb-adapter?badge)
 
 MongoDB Adapter is the [Mongo DB](https://www.mongodb.com) adapter for [Casbin](https://github.com/casbin/casbin). With this library, Casbin can load policy from MongoDB or save policy to it.
 


### PR DESCRIPTION
## What changes were made

### 1. Fix CI workflow startup failure (Apache org actions allowlist)
The CI workflow previously used two third-party actions that are **not allowed** in the `apache` organization:
- `supercharge/mongodb-github-action@1.7.0`
- `shogo82148/actions-goveralls@v1`

This caused the workflow to fail at startup ("Startup failure") before any test could run. Both have been removed:
- The MongoDB replica set (port 42069, required by transaction tests) is now started directly with the official `mongo:4.4` image via `docker run` + `rs.initiate()`, no third-party action needed.
- Coverage upload has been dropped (the corresponding dead badge was also removed from README).
- `actions/checkout` and `actions/setup-go` upgraded from v2 to v4 (official GitHub actions, allowlisted).

### 2. Fix release workflow bugs
- The "Write release notes" step only printed to stdout and never wrote `release-notes.md`, but the next step referenced it via `body_path` — the release would have failed on every tag push. Release notes are now written to the file.
- Replaced `softprops/action-gh-release@v2` (also not guaranteed on the Apache allowlist) with the built-in `gh` CLI, which is idempotent (re-running safely updates the existing release).

### 3. Polish README
- Added the standard Apache License header (required by the ASF RAT check).
- Restructured the badge row: title on its own line, badges on the second line, aligned with the `apache/casbin` main repo style.
- All badges now point to `apache/casbin-mongodb-adapter` instead of the old `casbin/mongodb-adapter` links.

## Checklist
- [x] CI workflow passes the Apache org actions allowlist (only official `actions/*` used)
- [x] `release-notes.md` is actually generated before the release step
- [x] README has the Apache license header and valid badges